### PR TITLE
fix: 修复html_table不完整的表头结构

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -36,6 +36,8 @@ def generate_html_table(data):
         <thead>
             <tr>
                 <th>Name</th>
+                <th>Class ID</th>
+                <th>Class Type</th>
                 <th>Grade Score</th>
                 <th>GPA</th>
                 <th>Credit</th>


### PR DESCRIPTION
修复html_table不完整的表头结构导致imgkit生成的图片缺少个别元素的问题